### PR TITLE
Add AGENTS.md documenting profile README dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a **GitHub profile README** (`Esteban3123/Esteban3123`). It contains only `README.md` — there is no application code, no dependency manifest (`package.json`, `requirements.txt`, etc.), no build system, and no automated tests.
+
+- **There is nothing to install, build, lint, or test.** The startup update script is intentionally a no-op.
+- **The "product" is the rendered profile page.** GitHub renders `README.md` on the user's profile. To preview it locally the way GitHub does, you can run a Markdown preview server such as `grip` (`pip install grip` then `grip README.md 0.0.0.0:6419`) and open the served URL in a browser. `grip` is a preview convenience only and is not a project dependency.
+- **External images may not load in the cloud VM.** The README embeds images from `github-readme-stats.vercel.app` and a generated `snake.svg`. These can fail (5xx) behind the sandbox network proxy; that is an egress limitation, not a repo problem, and they render fine on GitHub itself.
+- The `snake.svg` animation is produced by a GitHub Action and lives on a separate `output` branch, not in `main`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repository is a **GitHub profile README** (`Esteban3123/Esteban3123`) — it contains only `README.md`, with no application code, dependency manifest, build system, or tests.

As part of setting up a development environment, this PR adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing the durable, non-obvious facts for future agents:

- There is nothing to install/build/lint/test; the startup update script is a no-op (`true`).
- The "product" is the rendered profile page; it can be previewed locally with a Markdown preview server such as `grip`.
- External stats/snake images may fail behind the sandbox network proxy (egress limitation, not a repo issue).
- The `snake.svg` animation is generated by a GitHub Action on a separate `output` branch.

## Verification

I ran a local `grip` preview server against `README.md` and confirmed it renders exactly as GitHub does — the heading, the tech-stack icons (JavaScript/TypeScript/HTML5/CSS3/Python), and the Gmail badge all display correctly.

[profile_readme_preview.mp4](https://cursor.com/agents/bc-9d217d78-abe0-47d8-87c8-935ec05d39ac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprofile_readme_preview.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d217d78-abe0-47d8-87c8-935ec05d39ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d217d78-abe0-47d8-87c8-935ec05d39ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

